### PR TITLE
Updates all dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,20 +13,27 @@
     "url": "https://github.com/airtame/css.git"
   },
   "main": "index.js",
-  "files": ["index.js", "rules"],
-  "keywords": ["airtame", "stylelint", "stylelint-config"],
+  "files": [
+    "index.js",
+    "rules"
+  ],
+  "keywords": [
+    "airtame",
+    "stylelint",
+    "stylelint-config"
+  ],
   "devDependencies": {
-    "@babel/core": "^7.0.0-beta.32",
-    "babel-preset-env": "^1.6.1",
-    "jest": "^21.2.1",
-    "stylelint": "^8.2.0"
+    "@babel/core": "^7.11.6",
+    "babel-preset-env": "^1.7.0",
+    "jest": "^26.4.2",
+    "stylelint": "^13.7.1"
   },
   "peerDependencies": {
-    "stylelint": "^8.2.0"
+    "stylelint": "^13.7.1"
   },
   "dependencies": {
-    "stylelint-order": "^0.7.0",
-    "stylelint-scss": "^3.0.0"
+    "stylelint-order": "^4.1.0",
+    "stylelint-scss": "^3.18.0"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
We're importing this and I was seeing warnings such as these, which I could't get rid of, since they're transitive through this:

```bash
npm WARN stylelint-config-airtame@1.1.1 requires a peer of stylelint@^8.2.0 but none is installed. You must install peer dependencies yourself.
npm WARN stylelint-order@0.7.0 requires a peer of stylelint@^8.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN stylelint-scss@2.5.0 requires a peer of stylelint@^8.0.0 || ^9.0.0 but none is installed. You must install peer dependencies yourself.
```

This is just the result of running `ncu -u`.